### PR TITLE
Stop save popup off-tab

### DIFF
--- a/js/main/options.js
+++ b/js/main/options.js
@@ -12,7 +12,7 @@ function save(sav=player, force=false) {
 		all[sav.savePos - 1] = ENString(sav);
 	} else all.push(ENString(sav));
 	localStorage.setItem("dist-inc-saves" + betaID, btoa(JSON.stringify(all)));
-	notifier.success("Game saved!");
+	if (document.hasFocus()) notifier.success("Game saved!");
 }
 
 function setSave(ns, cod=false) {


### PR DESCRIPTION
Whenever you leave the tab (not close it), the save notifications build-up, and then when you go back on to the tab, it spams you with "Game Saved". This PR fixes this.