### PR TITLE
Fix numbers not being fixed width in some fonts

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,6 +14,7 @@
 	margin: 0;
 	padding: 0;
 	font-family: var(--font);
+	font-variant-numeric: tabular-nums;
 }
 
 *:focus {


### PR DESCRIPTION
From MDN [1]:

`tabular-nums` activating the set of figures where numbers are all of the same size, allowing them to be easily aligned like in tables.

Out of the fonts currently selectable in settings, this only visibly affects Comic Sans MS as it is the only font with proportional numbers.

[1]: https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric