### PR TITLE
Fix boost to perk strength from demonic souls

### DIFF
--- a/js/constants/achievements.js
+++ b/js/constants/achievements.js
@@ -424,7 +424,7 @@ const ACH_DATA = {
 		131: "Rockets, Cadavers, & Pathogens are gained twice as fast, and Dark Flow is showNum(50)% fasterboolean(extreme, and coal & enhanced coal gain is always 100x faster).",
 		132: "The Gauge Force Effect is doubled.",
 		133: "Unlock Auto-Elementaries.",
-		135: "The Purge Power effect is halved.",
+		135: "The Purge Power effect is halved, and boost to perk strength from Demonic Souls is based on best Demonic Souls.",
 
 		141: "boolean(hikers_dream,Keep generators and buy them automatically.)",
 		142: "Endorsements that are bought automatically do not reset anything.",

--- a/js/constants/default.js
+++ b/js/constants/default.js
@@ -36,7 +36,7 @@ const DEFAULT_START = {
 	bestA: new ExpantaNum(0),
 	bestEnd: new ExpantaNum(0),
 	bestEP: new ExpantaNum(0),
-	bestDemonicSouls: new ExpantaNum(1),
+	bestDemonicSouls: new ExpantaNum(0),
 	velocity: new ExpantaNum(0),
 	rank: new ExpantaNum(1),
 	tier: new ExpantaNum(0),

--- a/js/constants/default.js
+++ b/js/constants/default.js
@@ -36,6 +36,7 @@ const DEFAULT_START = {
 	bestA: new ExpantaNum(0),
 	bestEnd: new ExpantaNum(0),
 	bestEP: new ExpantaNum(0),
+	bestDemonicSouls: new ExpantaNum(1),
 	velocity: new ExpantaNum(0),
 	rank: new ExpantaNum(1),
 	tier: new ExpantaNum(0),

--- a/js/functions/misc.js
+++ b/js/functions/misc.js
@@ -238,6 +238,7 @@ function transformToEN(obj, sc = DEFAULT_START) {
 	ret.bestA = new ExpantaNum(ret.bestA)
 	ret.bestEnd = new ExpantaNum(ret.bestEnd)
 	ret.bestEP = new ExpantaNum(ret.bestEP)
+	ret.bestDemonicSouls = new ExpantaNum(ret.bestDemonicSouls);
 	ret.elementary.times = new ExpantaNum(ret.elementary.times);
 	ret.elementary.particles = new ExpantaNum(ret.elementary.particles);
 	ret.elementary.fermions.amount = new ExpantaNum(ret.elementary.fermions.amount);

--- a/js/main/inf.js
+++ b/js/main/inf.js
@@ -730,7 +730,7 @@ function updateTempPantheon() {
 		tmp.inf.pantheon.soulGain = tmp.inf.pantheon.soulGain.times(mul)
 	}
 	let h = player.inf.pantheon.heavenlyChips;
-	let d = player.inf.pantheon.demonicSouls;
+	let d = tmp.ach[135].has ? player.bestDemonicSouls : player.inf.pantheon.demonicSouls;
 	let p = player.inf.pantheon.purge.unl ? player.inf.pantheon.purge.power : new ExpantaNum(0);
 	if (mltRewardActive(5)) {
 		tmp.inf.pantheon.ppe = p.div(10).plus(1).log10().times(-0.01)
@@ -1027,6 +1027,8 @@ function infTick(diff) {
 		player.inf.pantheon.demonicSouls = player.inf.pantheon.demonicSouls.plus(
 			diff.times(adjustGen(tmp.inf.pantheon.soulGain, "demonicSouls"))
 		);
+		player.bestDemonicSouls = player.bestDemonicSouls.max(player.inf.pantheon.demonicSouls);
+
 		if (mltRewardActive(5)) player.inf.pantheon.hauntingEnergy = player.inf.pantheon.hauntingEnergy.plus(diff.times(adjustGen(tmp.inf.pantheon.hauntingEnergyGain, "hauntingEnergy")))
 		if (tmp.inf.pantheon.totalGems.gte(2)) player.inf.pantheon.purge.unl = true;
 	}

--- a/js/main/inf.js
+++ b/js/main/inf.js
@@ -378,7 +378,7 @@ function updateTempAscension() {
 	tmp.inf.asc.perkStrength = ExpantaNum.add(1, tmp.inf.asc.powerEff);
 	if (extremeStadiumComplete("nullum")) tmp.inf.asc.perkStrength = tmp.inf.asc.perkStrength.plus(0.25)
 	if (tmp.inf.upgs.has("7;1")) tmp.inf.asc.perkStrength = tmp.inf.asc.perkStrength.times(INF_UPGS.effects["7;1"]());
-	tmp.inf.asc.perkStrength = tmp.inf.asc.perkStrength.times(tmp.soulBoost ? tmp.soulBoost : 1);
+	tmp.inf.asc.perkStrength = tmp.inf.asc.perkStrength.times(tmp.inf.pantheon && tmp.inf.pantheon.soulBoost ? tmp.inf.pantheon.soulBoost : 1);
 	if (tmp.elm)
 		if (player.elementary.times.gt(0))
 			tmp.inf.asc.perkStrength = tmp.inf.asc.perkStrength.times(tmp.elm.ferm.leptonR("electron").plus(1));
@@ -991,7 +991,6 @@ function updateTempInf() {
 			tmp.inf.layer.reset(true);
 		};
 		tmp.canCompleteStadium = tmp.inf.stadium.canComplete;
-		if (!tmp.soulBoost) tmp.soulBoost = tmp.inf.pantheon.soulBoost;
 		if (!tmp.doDervReset) tmp.doDervReset = tmp.inf.derv.resetDervs;
 	}
 	

--- a/js/main/inf.js
+++ b/js/main/inf.js
@@ -730,7 +730,8 @@ function updateTempPantheon() {
 		tmp.inf.pantheon.soulGain = tmp.inf.pantheon.soulGain.times(mul)
 	}
 	let h = player.inf.pantheon.heavenlyChips;
-	let d = tmp.ach[135].has ? player.bestDemonicSouls : player.inf.pantheon.demonicSouls;
+	let adjustedD = tmp.ach[135].has ? player.bestDemonicSouls : player.inf.pantheon.demonicSouls;
+	let d = player.inf.pantheon.demonicSouls;
 	let p = player.inf.pantheon.purge.unl ? player.inf.pantheon.purge.power : new ExpantaNum(0);
 	if (mltRewardActive(5)) {
 		tmp.inf.pantheon.ppe = p.div(10).plus(1).log10().times(-0.01)
@@ -738,14 +739,14 @@ function updateTempPantheon() {
 		if (tmp.ach[135].has) tmp.inf.pantheon.ppe = tmp.inf.pantheon.ppe.times(2)
 		if (hasDE(9)) tmp.inf.pantheon.ppe = tmp.inf.pantheon.ppe.times(ExpantaNum.pow(1.01, player.elementary.theory.preons.boosters))
 		tmp.inf.pantheon.chipBoost = h.times(d.pow(tmp.inf.pantheon.ppe.times(-1)).plus(1)).plus(1).log10().plus(1).log10().plus(1);
-		tmp.inf.pantheon.soulBoost = d.times(h.pow(tmp.inf.pantheon.ppe.times(-1)).plus(1)).plus(1).log10().plus(1).log10().plus(1);
+		tmp.inf.pantheon.soulBoost = adjustedD.times(h.pow(tmp.inf.pantheon.ppe.times(-1)).plus(1)).plus(1).log10().plus(1).log10().plus(1);
 	} else {
 		tmp.inf.pantheon.ppe = p.div(10).plus(1).log10().plus(1).pow(-1);
 		if (tmp.inf.upgs.has("10;4")) tmp.inf.pantheon.ppe = tmp.inf.pantheon.ppe.div(2)
 		if (tmp.ach[135].has) tmp.inf.pantheon.ppe = tmp.inf.pantheon.ppe.div(2)
 		if (hasDE(9)) tmp.inf.pantheon.ppe = tmp.inf.pantheon.ppe.div(ExpantaNum.pow(1.01, player.elementary.theory.preons.boosters))
 		tmp.inf.pantheon.chipBoost = h.div(d.pow(tmp.inf.pantheon.ppe).plus(1)).plus(1).log10().plus(1).log10().plus(1);
-		tmp.inf.pantheon.soulBoost = d.div(h.pow(tmp.inf.pantheon.ppe).plus(1)).plus(1).log10().plus(1).log10().plus(1);
+		tmp.inf.pantheon.soulBoost = adjustedD.div(h.pow(tmp.inf.pantheon.ppe).plus(1)).plus(1).log10().plus(1).log10().plus(1);
 	}
 	if (!mltRewardActive(5)) {
 		if (tmp.inf.pantheon.chipBoost.gte(2)) tmp.inf.pantheon.chipBoost = tmp.inf.pantheon.chipBoost.slog(2).times(2);


### PR DESCRIPTION
Boost to perk strength from demonic souls is currently only updated once per reload.

Fixing this created a balance issue which would make it difficult/impossible to complete MV3. To fix this achievement 135 makes it so that boost to perk strength is based on best demonic souls. This fixes the MV3 balance issue.